### PR TITLE
Implement inventory whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ config.dev_tools_enabled = true
 ```
 
 ## Advanced Usage
-### Defining Offerable Content
-#### Scopes
+### Product Scopes
 Scoping options can be defined to constrain products to a narrower set of records. Let's say that we want to sell both large and small baskets:
 ```ruby
 class Basket < ApplicationRecord
@@ -119,6 +118,21 @@ class Basket < ApplicationRecord
   
   acts_as_offerable do |offer|
     offer.add_scope :style, title: 'Size', options: %i[small large] 
+  end
+end
+```
+
+### Inventory Whitelist
+To hide records from the inventory without de-scoping them from the product, you can specify an existing ActiveRecord scope to define the available inventory with.  
+
+This can be useful for excluding inventory that is sold, reserved, or otherwise unavailable.
+
+```ruby
+class Basket < ApplicationRecord
+  scope :in_warehouse, -> { where arrived_at_warehouse: true }
+  
+  acts_as_offerable do |offer|
+    offer.inventory_whitelist :in_warehouse 
   end
 end
 ```

--- a/app/models/accountability/offerable.rb
+++ b/app/models/accountability/offerable.rb
@@ -2,7 +2,7 @@
 
 class Accountability::Offerable
   cattr_accessor :collection, default: {}
-  attr_accessor :tenant, :category, :class_name, :trait, :scopes, :properties, :callbacks
+  attr_accessor :tenant, :category, :class_name, :trait, :scopes, :properties, :callbacks, :whitelist
 
   def initialize(category, tenant: :default, trait: nil, class_name:)
     @category = category
@@ -12,6 +12,7 @@ class Accountability::Offerable
     @scopes = {}
     @properties = {}
     @callbacks = {}
+    @whitelist = :all
   end
 
   def self.add(category, tenant: :default, trait: nil, class_name:)
@@ -22,18 +23,44 @@ class Accountability::Offerable
     offerable
   end
 
+  # Used when creating a product to define queries identifying saleable records from the host table.
+  # This can be used to de-scope sold inventory, but it is recommended to define a whitelist for that instead.
+  #
+  # CONSIDER: Add a parameter for indicating optional scopes
   def add_scope(name, title: name, options: :auto)
     scopes[name] = { title: title.to_s, options: options, category: category }
 
     self
   end
 
-  def add_property(name, title: name, position: nil)
-    position = properties.size.next if position.nil?
-    properties[name] = { title: title.to_s, position: position }
+  # Used for limiting the product's full inventory scope to a subset.
+  # Non-whitelisted records will be treated the same as a private product's inventory.
+  #
+  # The method takes the name of a pre-defined ActiveRecord scope as an argument.
+  # If no whitelist is specified, :all will be used instead.
+  def inventory_whitelist(whitelist_scope)
+    self.whitelist = whitelist_scope.to_sym
+
     self
   end
 
+  # Used to differentiate records within a product's scope/inventory.
+  # For example, consider a co-location that allows customers to choose their own cabinet:
+  #   `offer.add_property :cabinet_location_column, title: 'Asset Tag'`
+  #
+  # Use the `position` column if it is important that the properties display in a specific order.
+  #
+  # CONSIDER: Add support for property-specific pricing
+  def add_property(name, title: name, position: nil)
+    position = properties.size.next if position.nil?
+    properties[name] = { title: title.to_s, position: position }
+
+    self
+  end
+
+  # Used for setting multiple properties in a single line.
+  # Column names will be used as titles, and property order retained.
+  # `offer.add_properties :asset_tag, :room_number, :color`
   def add_properties(*names)
     names.each do |name|
       add_property(name)

--- a/app/models/accountability/product.rb
+++ b/app/models/accountability/product.rb
@@ -39,6 +39,12 @@ module Accountability
       source_class.where(**source_scope)
     end
 
+    def available_inventory
+      return [] if source_class.nil?
+
+      source_class.where(**source_scope).public_send(offerable_template.whitelist)
+    end
+
     # TODO: Update offerable_template.scopes to return an array of Scope objects and delegate to that instead
     def scopes
       return @scopes if @scopes.present?


### PR DESCRIPTION
This will enable users to keep a products's inventory item within scope while still taking it off the market.

Rationale: A basket that has been sold would still be expected to be defined as that same product. Nothing has changed apart from its availability.

This is being added so that subscription packages don't have to disappear after being disabled on one of the applications using the gem.

We will probably want to update the inventory_whitelist method to accept queryable arguments instead. This will do the trick for now though.