### PR TITLE
Add support for Inventory ordering

### DIFF
--- a/app/models/accountability/inventory.rb
+++ b/app/models/accountability/inventory.rb
@@ -31,11 +31,18 @@ module Accountability
     def source_records
       records = source_class.where(**source_scope).includes(:price_overrides)
       records = records.public_send(offerable_template.whitelist) if scope_availability?
+      records = records.order(@order_params) if @order_params.present?
       records
     end
 
     def available
       @scope_availability = true
+
+      self
+    end
+
+    def order(order_params)
+      @order_params = order_params
 
       self
     end


### PR DESCRIPTION
## Changes
- [x] Add Inventory#order method

This is necessary for allowing host applications to display their inventory in the desired order.

Example usage:
```ruby
@product.inventory_items.order(created_at: :dec)
@product.inventory_items.available.order(:price)
```

The parameters are stored in an instance variable and referenced when the query is executed if they are present.
