### PR TITLE
Run validations prior to checkout

### DIFF
--- a/app/models/accountability/order_group.rb
+++ b/app/models/accountability/order_group.rb
@@ -16,7 +16,8 @@ module Accountability
       transaction(requires_new: true, joinable: false) do
         trigger_callback :before_checkout
 
-        complete!
+        complete! && validate!
+        account.primary_billing_configuration.validate!
 
         # Without this transaction block, the credits will
         # stick around, and not try to charge again.


### PR DESCRIPTION
This way we don't risk them failing after making the charge.

Note: This solution is just a patch. We will need to implement a more thorough fix later on that accounts for other possible charge triggers.
