### PR TITLE
Add TODO: reminder to fix Zip casting

### DIFF
--- a/app/controllers/accountability/billing_configurations_controller.rb
+++ b/app/controllers/accountability/billing_configurations_controller.rb
@@ -7,6 +7,8 @@ module Accountability
 
     def new; end
 
+    # TODO: Ensure values are not being casted before they reach validations.
+    # Specifically, it seems Zip when not a number ends up being casted to 0 and passes validation.
     def create
       bc_params = billing_configuration_params
       @billing_configuration = @account.build_billing_configuration_with_active_merchant_data(bc_params,


### PR DESCRIPTION
It appears that somewhere between billing_cpnfigurations being built and it
being saved, the value of zip will be type casted into an integer. This is an
issue if the value was alphanumeric, causing it to result as 0 and pass
validations.

A bigger part of this issue is that we do not allow for alphanumeric values.
Perhaps solving for that will also solve this issue.